### PR TITLE
Update cache control header in SWR

### DIFF
--- a/lib/swr.js
+++ b/lib/swr.js
@@ -8,7 +8,7 @@ export function SWR(url, interval = 300000) {
     method: "GET",
     headers: {
      "Content-Type": "application/json",
-     "Cache-Control": "max-age=300",
+     "Cache-Control": "max-age=600",
     },
    }).then((res) => res.json()),
   { refreshInterval: interval }


### PR DESCRIPTION
## Update cache control header in SWR
- `max-age` is now `600ms` (10 minutes) instead of `300ms` (5 minutes)